### PR TITLE
Locate other files fix

### DIFF
--- a/LegendsViewer/FileLoader.cs
+++ b/LegendsViewer/FileLoader.cs
@@ -298,88 +298,58 @@ namespace LegendsViewer
         {
             FileInfo fileInfo = new FileInfo(xmlFile);
             string directory = fileInfo.DirectoryName;
-            string region = "";
-            if (fileInfo.Name.Contains(FileIdentifierLegendsXml))
-            {
-                region = fileInfo.Name.Replace(FileIdentifierLegendsXml, "");
-            }
-            else if (fileInfo.Name.Contains(FileIdentifierLegendsPlusXml))
-            {
-                region = fileInfo.Name.Replace(FileIdentifierLegendsPlusXml, "");
-            }
-            else
-            {
-                return;
-            }
 
-            SaveDirectory = directory;
-            RegionId = region;
+            XmlState = FileState.NotReady;
+            HistoryState = FileState.NotReady;
+            SitesState = FileState.NotReady;
+            MapState = FileState.NotReady;
+            XmlPlusState = FileState.NotReady;
 
-            string pathLegendsXml = Path.Combine(directory, region + FileIdentifierLegendsXml);
-            string pathWorldHistoryTxt = Path.Combine(directory, region + FileIdentifierWorldHistoryTxt);
-            string pathWorldSitesAndPopsTxt = Path.Combine(directory, region + FileIdentifierWorldSitesAndPops);
-            string pathWorldMapBmp = Path.Combine(directory, region + FileIdentifierWorldMapBmp);
-            string pathLegendsPlusXml = Path.Combine(directory, region + FileIdentifierLegendsPlusXml);
-
-            if (File.Exists(pathLegendsXml))
+            foreach (var file in Directory.EnumerateFiles(directory))
             {
-                _xmlText.Text = pathLegendsXml;
-                XmlState = FileState.Ready;
-            }
-            else
-            {
-                XmlState = FileState.NotReady;
-            }
-            if (File.Exists(pathWorldHistoryTxt))
-            {
-                _historyText.Text = pathWorldHistoryTxt;
-                HistoryState = FileState.Ready;
-            }
-            else
-            {
-                HistoryState = FileState.NotReady;
-            }
-            if (File.Exists(pathWorldSitesAndPopsTxt))
-            {
-                _sitesText.Text = pathWorldSitesAndPopsTxt;
-                SitesState = FileState.Ready;
-            }
-            else
-            {
-                SitesState = FileState.NotReady;
-            }
-            if (File.Exists(pathWorldMapBmp))
-            {
-                _mapText.Text = pathWorldMapBmp;
-                MapState = FileState.Ready;
-            }
-            else
-            {
-                string imageFile = Directory.GetFiles(directory)
-                    .FirstOrDefault(file =>
-                        file.Contains(region) &&
-                        (file.EndsWith(".bmp") ||
-                         file.EndsWith(".png") ||
-                         file.EndsWith(".jpg") ||
-                         file.EndsWith(".jpeg")));
-                if (!string.IsNullOrEmpty(imageFile))
+                if (file.EndsWith(FileIdentifierLegendsXml))
                 {
-                    _mapText.Text = imageFile;
+                    _xmlText.Text = file;
+                    XmlState = FileState.Ready;
+                }
+
+                if (file.EndsWith(FileIdentifierWorldHistoryTxt))
+                {
+                    _historyText.Text = file;
+                    HistoryState = FileState.Ready;
+                }
+
+                if (file.EndsWith(FileIdentifierWorldSitesAndPops))
+                {
+                    _sitesText.Text = file;
+                    SitesState = FileState.Ready;
+                }
+
+                if (file.EndsWith(FileIdentifierWorldMapBmp))
+                {
+                    _mapText.Text = file;
                     MapState = FileState.Ready;
                 }
-                else
+                else if (String.IsNullOrEmpty(_mapText.Text))
                 {
-                    MapState = FileState.NotReady;
+                    string imageFile = Directory.GetFiles(directory)
+                        .FirstOrDefault(f =>
+                            (f.EndsWith(".bmp") ||
+                             f.EndsWith(".png") ||
+                             f.EndsWith(".jpg") ||
+                             f.EndsWith(".jpeg")));
+                    if (!string.IsNullOrEmpty(imageFile))
+                    {
+                        _mapText.Text = imageFile;
+                        MapState = FileState.Ready;
+                    }
                 }
-            }
-            if (File.Exists(pathLegendsPlusXml))
-            {
-                _xmlPlusText.Text = pathLegendsPlusXml;
-                XmlPlusState = FileState.Ready;
-            }
-            else
-            {
-                XmlPlusState = FileState.NotReady;
+
+                if (file.EndsWith(FileIdentifierLegendsPlusXml))
+                {
+                    _xmlPlusText.Text = file;
+                    XmlPlusState = FileState.Ready;
+                }
             }
         }
 

--- a/LegendsViewer/FileLoader.cs
+++ b/LegendsViewer/FileLoader.cs
@@ -286,7 +286,7 @@ namespace LegendsViewer
         private void XmlPlusClick(object sender, EventArgs e)
         {
             string xmlFile = GetFile("Legends XML Plus|*legends_plus.xml;|Legends XML Plus|*.xml;|All Files|*.*");
-            if (string.IsNullOrEmpty(xmlFile))
+            if (!string.IsNullOrEmpty(xmlFile))
             {
                 _xmlPlusText.Text = xmlFile;
                 XmlPlusState = FileState.Ready;

--- a/LegendsViewer/FileLoader.cs
+++ b/LegendsViewer/FileLoader.cs
@@ -296,59 +296,32 @@ namespace LegendsViewer
 
         private void LocateOtherFiles(string xmlFile)
         {
-            FileInfo fileInfo = new FileInfo(xmlFile);
-            string directory = fileInfo.DirectoryName;
+            string directory = new FileInfo(xmlFile).DirectoryName;
 
-            XmlState = FileState.NotReady;
-            HistoryState = FileState.NotReady;
-            SitesState = FileState.NotReady;
-            MapState = FileState.NotReady;
-            XmlPlusState = FileState.NotReady;
+            _xmlText.Text = Directory.EnumerateFiles(directory, "*" + FileIdentifierLegendsXml).FirstOrDefault();
+            _historyText.Text = Directory.EnumerateFiles(directory, "*" + FileIdentifierWorldHistoryTxt).FirstOrDefault();
+            _sitesText.Text = Directory.EnumerateFiles(directory, "*" + FileIdentifierWorldSitesAndPops).FirstOrDefault();
+            _mapText.Text = Directory.EnumerateFiles(directory, "*" + FileIdentifierWorldMapBmp).FirstOrDefault();
+            _xmlPlusText.Text = Directory.EnumerateFiles(directory, "*" + FileIdentifierLegendsPlusXml).FirstOrDefault();
 
-            foreach (var file in Directory.EnumerateFiles(directory))
+            XmlState = String.IsNullOrEmpty(_xmlText.Text) ? FileState.NotReady : FileState.Ready;
+            HistoryState = String.IsNullOrEmpty(_historyText.Text) ? FileState.NotReady : FileState.Ready;
+            SitesState = String.IsNullOrEmpty(_sitesText.Text) ? FileState.NotReady : FileState.Ready;
+            MapState = String.IsNullOrEmpty(_mapText.Text) ? FileState.NotReady : FileState.Ready;
+            XmlPlusState = String.IsNullOrEmpty(_xmlPlusText.Text) ? FileState.NotReady : FileState.Ready;
+
+            if (String.IsNullOrEmpty(_mapText.Text))
             {
-                if (file.EndsWith(FileIdentifierLegendsXml))
+                string imageFile = Directory.GetFiles(directory)
+                    .FirstOrDefault(f =>
+                        (f.EndsWith(".bmp") ||
+                         f.EndsWith(".png") ||
+                         f.EndsWith(".jpg") ||
+                         f.EndsWith(".jpeg")));
+                if (!string.IsNullOrEmpty(imageFile))
                 {
-                    _xmlText.Text = file;
-                    XmlState = FileState.Ready;
-                }
-
-                if (file.EndsWith(FileIdentifierWorldHistoryTxt))
-                {
-                    _historyText.Text = file;
-                    HistoryState = FileState.Ready;
-                }
-
-                if (file.EndsWith(FileIdentifierWorldSitesAndPops))
-                {
-                    _sitesText.Text = file;
-                    SitesState = FileState.Ready;
-                }
-
-                if (file.EndsWith(FileIdentifierWorldMapBmp))
-                {
-                    _mapText.Text = file;
+                    _mapText.Text = imageFile;
                     MapState = FileState.Ready;
-                }
-                else if (String.IsNullOrEmpty(_mapText.Text))
-                {
-                    string imageFile = Directory.GetFiles(directory)
-                        .FirstOrDefault(f =>
-                            (f.EndsWith(".bmp") ||
-                             f.EndsWith(".png") ||
-                             f.EndsWith(".jpg") ||
-                             f.EndsWith(".jpeg")));
-                    if (!string.IsNullOrEmpty(imageFile))
-                    {
-                        _mapText.Text = imageFile;
-                        MapState = FileState.Ready;
-                    }
-                }
-
-                if (file.EndsWith(FileIdentifierLegendsPlusXml))
-                {
-                    _xmlPlusText.Text = file;
-                    XmlPlusState = FileState.Ready;
                 }
             }
         }


### PR DESCRIPTION
Hey, I really love Legends Viewer! Thanks for a great tool.

This is to fix a bug with the populating of other files.

When generating legends data from a region that has been renamed, Dwarf Fortress truncates the region name in the generated files to the first 20 characters, while dfhack does not.

So for a world "The_Infinite_Dimensions", you will have:

```plain
legends-The_Infinite_Dimensions-00125-01-01/
    ├ The_Infinite_Dimensi-00125-01-01-world_map.bmp
    ├ The_Infinite_Dimensi-00125-01-01-legends.xml
    └ The_Infinite_Dimensions-00125-01-01-legends_plus.xml
```

This messes with the locating of additional files.

- If you select the _legends_ file, the `region` is `The_Infinite_Dimensi-00125-01-01` and everything will populate except the _legends_plus_ file.
- If you select the _legends_plus_ file, the `region` is `The_Infinite_Dimensions-00125-01-01` and only the _legends_plus_ and the map will populate (the map file is the default from `FirstOrDefault`).

This PR addresses the issue by matching files based on their endings.

It also addresses a bug where you can't manually select a _legends_plus_ file because of a missing `!` not operator.
