### PR TITLE
Update XMLPlusParser.cs

### DIFF
--- a/LegendsViewer/Legends/Parser/XMLPlusParser.cs
+++ b/LegendsViewer/Legends/Parser/XMLPlusParser.cs
@@ -98,9 +98,10 @@ namespace LegendsViewer.Legends.Parser
 
             if (xmlParserSection > CurrentSection)
             {
-                while (xmlParserSection > CurrentSection)
+                while (xmlParserSection > CurrentSection && (null != _currentItem && Xml.ReadState != ReadState.Closed))
                 {
-                    AddItemToWorld(_currentItem);
+                    if(null != _currentItem)
+                      AddItemToWorld(_currentItem);
                     _currentItem = null;
                     Parse();
                 }


### PR DESCRIPTION
If there're no art forms, Parse will yield null. This causes the next AddItemToWorld to crash as _currentItem is still null. The proposed additional checks in this request are to safeguard against such situation.