### PR TITLE
Update XMLPlusParser.cs

### DIFF
--- a/LegendsViewer/Legends/Parser/XMLPlusParser.cs
+++ b/LegendsViewer/Legends/Parser/XMLPlusParser.cs
@@ -98,9 +98,11 @@ namespace LegendsViewer.Legends.Parser
 
             if (xmlParserSection > CurrentSection)
             {
-                while (xmlParserSection > CurrentSection)
+                while (xmlParserSection > CurrentSection &&
+                       (null != _currentItem || ReadState.Closed != Xml.ReadState))
                 {
-                    AddItemToWorld(_currentItem);
+                    if(null != _currentItem)
+                        AddItemToWorld(_currentItem);
                     _currentItem = null;
                     Parse();
                 }


### PR DESCRIPTION
If a world is genned with no art form, Parsing will correctly fail around that section, causing the next AddItemToWorld to crash as _currentItem remains null. The proposed checks are to safeguard against such situation.

This is the same PR I made the other day, but to the wrong branch.

There might be cleaner ways to deal with section omissions such as these but I couldnt figure that out.